### PR TITLE
Fix un-readable blockquote issue

### DIFF
--- a/themes/mellow.json
+++ b/themes/mellow.json
@@ -59,7 +59,7 @@
 		"activityBarBadge.background": "#57575f",
 		"activityBar.activeBorder": "#aca1cf",
 		"activityBar.border": "#131314",
-		"textBlockQuote.background": "#90b99f",
+		"textBlockQuote.background": "#1b1b1d",
 		"gitDecoration.addedResourceForeground": "#9dc6ac",
 		"gitDecoration.modifiedResourceForeground": "#f0c5a9",
 		"gitDecoration.deletedResourceForeground": "#ffae9f",


### PR DESCRIPTION
The block-quotes in markdown previews (maybe others too) is completely unreadable because of bright background and light foreground text. I am not sure of colors but other blocks/foregrounds were using this hex value as such until it's decided which one to use and is used, at minimum this should be done.